### PR TITLE
fix: add schema qualification to next() and most_recent()

### DIFF
--- a/src/rrule.sql
+++ b/src/rrule.sql
@@ -1814,7 +1814,7 @@ CREATE OR REPLACE FUNCTION "next"(
 )
 RETURNS TIMESTAMP AS $$
 BEGIN
-    RETURN "after"(rrule_string, dtstart, NOW()::TIMESTAMP);
+    RETURN rrule."after"(rrule_string, dtstart, NOW()::TIMESTAMP);
 END;
 $$ LANGUAGE plpgsql STABLE;
 
@@ -1831,7 +1831,7 @@ CREATE OR REPLACE FUNCTION "most_recent"(
 )
 RETURNS TIMESTAMP AS $$
 BEGIN
-    RETURN "before"(rrule_string, dtstart, NOW()::TIMESTAMP);
+    RETURN rrule."before"(rrule_string, dtstart, NOW()::TIMESTAMP);
 END;
 $$ LANGUAGE plpgsql STABLE;
 


### PR DESCRIPTION
## Summary

  The TIMESTAMP-based overloads of `next()` and `most_recent()` call `after()` and `before()` without the `rrule.` schema prefix, causing runtime errors when invoked.

  ## Problem

  SELECT rrule.next('FREQ=DAILY', '2026-01-01'::TIMESTAMP);

  Results in:

  ERROR: function after(character varying, timestamp without time zone, timestamp without time zone) does not exist

  ## Root Cause

  In `src/rrule.sql`, lines 1817 and 1834 call `"after"()` and `"before"()` without schema qualification. The TIMESTAMPTZ overloads (lines ~2314, ~2346) correctly use
  `rrule."after"()` and `rrule."before"()`.

  ## Fix

  Added `rrule.` schema prefix to both function calls:
  - Line 1817: `"after"(...)` → `rrule."after"(...)`
  - Line 1834: `"before"(...)` → `rrule."before"(...)`